### PR TITLE
feat: OpenAPI Docs & Swagger UI

### DIFF
--- a/server/docs/openapi.json
+++ b/server/docs/openapi.json
@@ -1,0 +1,15 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "MyJira API",
+    "version": "1.0.0",
+    "description": "REST API documentation for MyJira"
+  },
+  "servers": [
+    {
+      "url": "/api/v1",
+      "description": "Current server"
+    }
+  ],
+  "paths": {}
+}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,6 +15,7 @@
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
         "pg": "^8.20.0",
+        "swagger-ui-express": "^5.0.1",
         "winston": "^3.19.0",
         "zod": "^4.3.6"
       },
@@ -27,6 +28,7 @@
         "@types/node": "^25.3.3",
         "@types/pg": "^8.20.0",
         "@types/supertest": "^7.2.0",
+        "@types/swagger-ui-express": "^4.1.8",
         "cross-env": "^10.1.0",
         "dotenv-cli": "^11.0.0",
         "eslint": "^10.0.2",
@@ -1839,6 +1841,13 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
@@ -2248,6 +2257,17 @@
       "dependencies": {
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/@types/triple-beam": {
@@ -7867,6 +7887,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.2.tgz",
+      "integrity": "sha512-t6Ns52nS8LU2hqi0+rezMjFO1ZrCsCrnommXrU7Nfrg2va2dWahdvM6TuSwzdHpG29v6BHJyU1c/UWFhgVZzVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/synckit": {

--- a/server/package.json
+++ b/server/package.json
@@ -23,6 +23,7 @@
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "pg": "^8.20.0",
+    "swagger-ui-express": "^5.0.1",
     "winston": "^3.19.0",
     "zod": "^4.3.6"
   },
@@ -35,6 +36,7 @@
     "@types/node": "^25.3.3",
     "@types/pg": "^8.20.0",
     "@types/supertest": "^7.2.0",
+    "@types/swagger-ui-express": "^4.1.8",
     "cross-env": "^10.1.0",
     "dotenv-cli": "^11.0.0",
     "eslint": "^10.0.2",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,12 +1,17 @@
 import express from 'express';
-import { workspaceController } from '@/modules/workspace';
+import swaggerUi from 'swagger-ui-express';
 import { errorMiddleware, loggerRequestMiddleware } from '@/common/middlewares';
+import { workspaceController } from '@/modules/workspace';
+import openapiSpec from '../docs/openapi.json';
 
 const app = express();
 
 app.use(express.json());
 
 app.use(loggerRequestMiddleware);
+
+app.use('/docs', swaggerUi.serve);
+app.get('/docs', swaggerUi.setup(openapiSpec));
 
 app.use('/api/v1/workspace', workspaceController.router);
 


### PR DESCRIPTION
- OpenAPI json spec
- Swagger UI for visualization of the spec

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new `/docs` route and documentation dependencies without changing existing API behavior or data handling.
> 
> **Overview**
> Adds an initial OpenAPI 3.1 JSON spec at `server/docs/openapi.json` and wires Swagger UI into the server so the spec is viewable at `GET /docs`.
> 
> Updates `server/package.json`/lockfile to include `swagger-ui-express` (and its types) as dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdad0a7408fe4b1076c0040958a8d69f6ece341d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->