### PR TITLE
Feat: Business Rule Violation for bootstrapping workspace, Zod validation errors parsing, Strict bootstrap workspace body

### DIFF
--- a/server/src/common/middlewares/error.middleware.ts
+++ b/server/src/common/middlewares/error.middleware.ts
@@ -1,5 +1,7 @@
 import { NextFunction, Request, Response } from 'express';
+import { ZodError } from 'zod';
 import { AppError, ErrorCodes } from '@/common/errors';
+import { mapZodError } from '@/common/utils/map-zod-error';
 
 export const errorMiddleware = (
   err: Error | AppError,
@@ -7,6 +9,17 @@ export const errorMiddleware = (
   res: Response,
   _next: NextFunction, // eslint-disable-line @typescript-eslint/no-unused-vars
 ): Response => {
+  if (err instanceof ZodError) {
+    const validationError = mapZodError(err);
+    return res.status(validationError.status).json({
+      error: {
+        code: validationError.code,
+        message: validationError.message,
+        details: validationError.details,
+      },
+    });
+  }
+
   const status = err instanceof AppError ? err.status : 500;
   const code = err instanceof AppError ? err.code : ErrorCodes.INTERNAL_SERVER_ERROR;
   const message = err instanceof AppError ? err.message : 'Internal server error';

--- a/server/src/common/utils/map-zod-error.ts
+++ b/server/src/common/utils/map-zod-error.ts
@@ -1,0 +1,11 @@
+import { ZodError } from 'zod';
+import { ValidationError } from '../errors/validation-error';
+
+export function mapZodError(error: ZodError): ValidationError {
+  const fields = error.issues.map((issue) => ({
+    name: issue.path.join('.'),
+    message: issue.message,
+  }));
+
+  return new ValidationError(fields);
+}

--- a/server/src/modules/users/user.interface.ts
+++ b/server/src/modules/users/user.interface.ts
@@ -1,8 +1,13 @@
 import { IRepository } from '@/common/interfaces';
 import { User } from './user.schema';
-import { BulkCreateUsersParams, CreateUserParams } from './user.types';
+import {
+  BulkCreateUsersParams,
+  CreateUserParams,
+  HasUsersForWorkspaceRoleIdsParams,
+} from './user.types';
 
 export interface IUserRepository extends IRepository {
   createUser(params: CreateUserParams): Promise<User>;
   bulkCreateUsers(params: BulkCreateUsersParams): Promise<User[]>;
+  hasUsersForWorkspaceRoleIds(params: HasUsersForWorkspaceRoleIdsParams): Promise<boolean>;
 }

--- a/server/src/modules/users/user.repository.ts
+++ b/server/src/modules/users/user.repository.ts
@@ -2,7 +2,11 @@ import type { PrismaClient } from '../../../prisma/generated/prisma/client';
 import { ILogger, logger } from '@/common/logger';
 import { prisma } from '@/common/lib/prisma';
 import { mapPrismaError } from '@/common/utils/map-prisma-error';
-import { BulkCreateUsersParams, CreateUserParams } from './user.types';
+import {
+  BulkCreateUsersParams,
+  CreateUserParams,
+  HasUsersForWorkspaceRoleIdsParams,
+} from './user.types';
 import { User, UserSchema } from './user.schema';
 import { IUserRepository } from './user.interface';
 
@@ -54,6 +58,21 @@ export class UserRepository implements IUserRepository {
       });
 
       return users.map((user) => UserSchema.parse(user));
+    } catch (error) {
+      this.logError(error);
+      throw mapPrismaError(error);
+    }
+  }
+
+  public async hasUsersForWorkspaceRoleIds(
+    params: HasUsersForWorkspaceRoleIdsParams,
+  ): Promise<boolean> {
+    try {
+      const count = await this.prisma.user.count({
+        where: { workspaceRoleId: { in: params.workspaceRoleIds } },
+      });
+
+      return count > 0;
     } catch (error) {
       this.logError(error);
       throw mapPrismaError(error);

--- a/server/src/modules/users/user.types.ts
+++ b/server/src/modules/users/user.types.ts
@@ -8,3 +8,7 @@ export interface CreateUserParams {
 export interface BulkCreateUsersParams {
   users: CreateUserParams[];
 }
+
+export interface HasUsersForWorkspaceRoleIdsParams {
+  workspaceRoleIds: string[];
+}

--- a/server/src/modules/workspace/workspace.schema.ts
+++ b/server/src/modules/workspace/workspace.schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
 
-export const BootstrapWorkspaceUsersSchema = z.object({
+export const BootstrapWorkspaceUsersSchema = z.strictObject({
   bootstrapToken: z.string().min(1),
 });

--- a/server/src/modules/workspace/workspace.service.ts
+++ b/server/src/modules/workspace/workspace.service.ts
@@ -4,7 +4,11 @@ import {
   WorkspaceRole,
   WorkspaceRoleName,
 } from '@/modules/workspace-roles';
-import { AuthorizationError, ResourceNotFoundError } from '@/common/errors';
+import {
+  AuthorizationError,
+  BusinessRuleViolationError,
+  ResourceNotFoundError,
+} from '@/common/errors';
 import { ILogger } from '@/common/logger';
 import { IWorkspaceUsersConfig } from '@/config/workspace-users/workspace-users-config';
 import { BootstrapWorkspaceConfigParams, BootstrapWorkspaceUsersParams } from './workspace.types';
@@ -23,8 +27,8 @@ export class WorkspaceService implements IWorkspaceService {
     this.validateBootstrapToken(params.bootstrapToken);
 
     const workspaceRoles = await this.workspaceRoleRepository.getWorkspaceRoles();
-
     this.validateWorkspaceRoles(workspaceRoles);
+    await this.validateWorkspaceNotAlreadyBootstrapped(workspaceRoles);
 
     const usersConfig = await this.workspaceUsersConfig.getUsers(workspaceRoles);
     const users = await this.userRepository.bulkCreateUsers({ users: usersConfig });
@@ -50,6 +54,18 @@ export class WorkspaceService implements IWorkspaceService {
           resourceId: role,
         });
       }
+    }
+  }
+
+  private async validateWorkspaceNotAlreadyBootstrapped(workspaceRoles: WorkspaceRole[]) {
+    const workspaceRoleIds = workspaceRoles.map((role) => role.id);
+    const hasUsers = await this.userRepository.hasUsersForWorkspaceRoleIds({
+      workspaceRoleIds,
+    });
+
+    if (hasUsers) {
+      this.logger.warn('Workspace is already bootstrapped');
+      throw new BusinessRuleViolationError('Workspace is already bootstrapped');
     }
   }
 }

--- a/server/tests/integration/assertions/errors.assertions.ts
+++ b/server/tests/integration/assertions/errors.assertions.ts
@@ -32,3 +32,9 @@ export function expectBusinessRuleViolationError(response: supertest.Response): 
   expect(response.status).toBe(422);
   expect(response.body.error?.code).toBe(ErrorCodes.BUSINESS_RULE_VIOLATION);
 }
+
+export function expectValidationError(response: supertest.Response): void {
+  expect(response.status).toBe(400);
+  expect(response.body.error?.code).toBe(ErrorCodes.VALIDATION_ERROR);
+  expect(response.body.error?.details?.fields).toBeDefined();
+}

--- a/server/tests/integration/assertions/errors.assertions.ts
+++ b/server/tests/integration/assertions/errors.assertions.ts
@@ -27,3 +27,8 @@ export function expectResourceNotFoundError(
   expect(error?.code).toBe(ErrorCodes.RESOURCE_NOT_FOUND);
   expect(error?.details?.resource?.resourceName).toBe(resourceName);
 }
+
+export function expectBusinessRuleViolationError(response: supertest.Response): void {
+  expect(response.status).toBe(422);
+  expect(response.body.error?.code).toBe(ErrorCodes.BUSINESS_RULE_VIOLATION);
+}

--- a/server/tests/integration/modules/workspace/workspace.controller.test.ts
+++ b/server/tests/integration/modules/workspace/workspace.controller.test.ts
@@ -36,6 +36,7 @@ import {
   expectForbiddenError,
   expectInternalServerError,
   expectResourceNotFoundError,
+  expectValidationError,
 } from '../../assertions/errors.assertions';
 import {
   deleteAllWorkspaceRoles,
@@ -121,9 +122,7 @@ describe('Workspace Controller', () => {
       });
     });
 
-    // Once schema validation surfaces ValidationError instead of bubbling
-    // Zod failures, switch these assertions to `expectValidationError`.
-    describe.skip('on malformed request body', () => {
+    describe('on malformed request body', () => {
       it.each([
         { case: 'bootstrap token is undefined', body: { bootstrapToken: undefined } },
         { case: 'bootstrap token is omitted', body: {} },
@@ -132,10 +131,10 @@ describe('Workspace Controller', () => {
         { case: 'bootstrap token is boolean', body: { bootstrapToken: true } },
         { case: 'bootstrap token is null', body: { bootstrapToken: null } },
         { case: 'bootstrap token is empty', body: { bootstrapToken: '' } },
-      ])(`returns temporarily an internal server error when $case`, async ({ body }) => {
+      ])(`returns a validation error when $case`, async ({ body }) => {
         const response = await bootstrapWorkspaceUsers(body);
 
-        expectInternalServerError(response);
+        expectValidationError(response);
         await expectNoUsersInDatabase();
       });
     });

--- a/server/tests/integration/modules/workspace/workspace.controller.test.ts
+++ b/server/tests/integration/modules/workspace/workspace.controller.test.ts
@@ -137,6 +137,16 @@ describe('Workspace Controller', () => {
         expectValidationError(response);
         await expectNoUsersInDatabase();
       });
+
+      it('returns a validation error when valid bootstrap token but additional fields are present', async () => {
+        const response = await bootstrapWorkspaceUsers({
+          bootstrapToken: ctx.bootstrapToken,
+          additionalField: 'additionalField',
+        });
+
+        expectValidationError(response);
+        await expectNoUsersInDatabase();
+      });
     });
 
     describe('on missing workspace roles', () => {

--- a/server/tests/integration/modules/workspace/workspace.controller.test.ts
+++ b/server/tests/integration/modules/workspace/workspace.controller.test.ts
@@ -32,7 +32,7 @@ import {
   WorkspaceTestContext,
 } from './workspace.controller.fixtures';
 import {
-  expectConflictError,
+  expectBusinessRuleViolationError,
   expectForbiddenError,
   expectInternalServerError,
   expectResourceNotFoundError,
@@ -100,15 +100,13 @@ describe('Workspace Controller', () => {
       });
     });
 
-    // Replace with business-rule violation once the service stops
-    // delegating uniqueness enforcement to Prisma's unique constraint.
-    describe.skip('on already-bootstrapped workspace', () => {
-      it('returns a conflict error when a second bootstrap attempt is made and leaves the original users intact', async () => {
+    describe('on already-bootstrapped workspace', () => {
+      it('returns a business rule violation error when a second bootstrap attempt is made and leaves the original users intact', async () => {
         const firstResponse = await validBootstrap();
         expect(firstResponse.status).toBe(201);
 
         const secondResponse = await validBootstrap();
-        expectConflictError(secondResponse);
+        expectBusinessRuleViolationError(secondResponse);
 
         await expectUsersInDatabase(testUsers);
       });

--- a/server/tests/unit/common/utils/map-zod-error.test.ts
+++ b/server/tests/unit/common/utils/map-zod-error.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from '@jest/globals';
+import { z } from 'zod';
+import { mapZodError } from '@/common/utils/map-zod-error';
+import { ValidationError } from '@/common/errors';
+import { ErrorCodes } from '@/common/errors/error-codes';
+
+describe('mapZodError', () => {
+  function getZodError(schema: z.ZodType, input: unknown): z.ZodError {
+    const result = schema.safeParse(input);
+    if (result.success) {
+      throw new Error('Expected schema to fail');
+    }
+    return result.error;
+  }
+
+  it('should return a ValidationError with status 400 and VALIDATION_ERROR code', () => {
+    const schema = z.object({ name: z.string() });
+    const error = getZodError(schema, { name: 123 });
+
+    const result = mapZodError(error);
+
+    expect(result).toBeInstanceOf(ValidationError);
+    expect(result.status).toBe(400);
+    expect(result.code).toBe(ErrorCodes.VALIDATION_ERROR);
+  });
+
+  it('should map a single-field error to one IErrorField', () => {
+    const schema = z.object({ name: z.string() });
+    const error = getZodError(schema, { name: 123 });
+
+    const result = mapZodError(error);
+
+    expect(result.details?.fields).toHaveLength(1);
+    expect(result.details?.fields?.[0]).toEqual({
+      name: 'name',
+      message: expect.any(String),
+    });
+  });
+
+  it('should map multiple field errors to multiple IErrorFields', () => {
+    const schema = z.object({ name: z.string(), age: z.number() });
+    const error = getZodError(schema, { name: 123, age: 'old' });
+
+    const result = mapZodError(error);
+
+    expect(result.details?.fields).toHaveLength(2);
+    expect(result.details?.fields).toEqual(
+      expect.arrayContaining([
+        { name: 'name', message: expect.any(String) },
+        { name: 'age', message: expect.any(String) },
+      ]),
+    );
+  });
+
+  it('should join nested paths with a dot', () => {
+    const schema = z.object({ user: z.object({ email: z.string().email() }) });
+    const error = getZodError(schema, { user: { email: 'not-an-email' } });
+
+    const result = mapZodError(error);
+
+    expect(result.details?.fields?.[0]?.name).toBe('user.email');
+  });
+
+  it('should use an empty string as field name when path is empty', () => {
+    const schema = z.string();
+    const error = getZodError(schema, 123);
+
+    const result = mapZodError(error);
+
+    expect(result.details?.fields?.[0]?.name).toBe('');
+  });
+});

--- a/server/tests/unit/mocks/user.repository.mock.ts
+++ b/server/tests/unit/mocks/user.repository.mock.ts
@@ -6,5 +6,6 @@ export function createMockUserRepository(): jest.Mocked<IUserRepository> {
     resourceName: 'users',
     createUser: jest.fn(),
     bulkCreateUsers: jest.fn(),
+    hasUsersForWorkspaceRoleIds: jest.fn(),
   };
 }

--- a/server/tests/unit/modules/workspace/workspace.service.test.ts
+++ b/server/tests/unit/modules/workspace/workspace.service.test.ts
@@ -3,7 +3,11 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { IWorkspaceService } from '@/modules/workspace/workspace.interface';
 import { WorkspaceService } from '@/modules/workspace/workspace.service';
 
-import { AuthorizationError, ResourceNotFoundError } from '@/common/errors';
+import {
+  AuthorizationError,
+  BusinessRuleViolationError,
+  ResourceNotFoundError,
+} from '@/common/errors';
 
 import {
   BootstrapWorkspaceConfigParams,
@@ -47,6 +51,7 @@ describe('WorkspaceService', () => {
     beforeEach(() => {
       mockUserRepository = createMockUserRepository();
       mockUserRepository.bulkCreateUsers.mockResolvedValue(mockUsersAfterBulkCreate);
+      mockUserRepository.hasUsersForWorkspaceRoleIds.mockResolvedValue(false);
 
       mockWorkspaceRoleRepository = createMockWorkspaceRoleRepository();
       mockWorkspaceRoleRepository.getWorkspaceRoles.mockResolvedValue(mockWorkspaceRoles);
@@ -125,6 +130,14 @@ describe('WorkspaceService', () => {
       await expect(
         workspaceService.bootstrapWorkspaceUsers(mockBootstrapWorkspaceUsersParams),
       ).rejects.toThrow(ResourceNotFoundError);
+    });
+
+    it('should throw a business rule violation error when workspace is already bootstrapped', async () => {
+      mockUserRepository.hasUsersForWorkspaceRoleIds.mockResolvedValue(true);
+
+      await expect(
+        workspaceService.bootstrapWorkspaceUsers(mockBootstrapWorkspaceUsersParams),
+      ).rejects.toThrow(BusinessRuleViolationError);
     });
 
     it('should propagate an error when bulk create users fails', async () => {


### PR DESCRIPTION
- Replaced Prisma's conflict error with Business Rule Violation error when trying to bootstrap the workspace for the second time
- Added mapping for zod errors to app validation errors
- Made bootstrap workspace body to be strict and don't allow additional fields to be passed